### PR TITLE
Make go-ncs compile on Mac OS

### DIFF
--- a/ncs.h
+++ b/ncs.h
@@ -1,6 +1,9 @@
 #ifndef _GONCS_H_
 #define _GONCS_H_
 
+#ifdef __APPLE__
+#include <sys/types.h>
+#endif // __APPLE__
 #include <stdlib.h>
 #include <mvnc.h>
 


### PR DESCRIPTION
When building the package against the NCSDK V1 API locally on macOS I encountered the following error:

```shell
~/go/src/github.com/hybridgroup/go-ncs (master)$ go build
# github.com/hybridgroup/go-ncs
In file included from ./ncs.go:5:
./ncs.h:11:3: error: unknown type name 'uint'; did you mean 'int'?
  uint length;
  ^~~~
  int
1 error generated.
```

This was due to missing header file when compiling on macOS platform which this commit includes in the `ncs.h` file.