### PR TITLE
NewMatFromBytes returns 2 values

### DIFF
--- a/cmd/caffe/main.go
+++ b/cmd/caffe/main.go
@@ -88,7 +88,11 @@ func main() {
 	}
 
 	// convert results from fp16 back to float32
-	fp16Results := gocv.NewMatFromBytes(1, len(data)/2, gocv.MatTypeCV16S, data)
+	fp16Results, err := gocv.NewMatFromBytes(1, len(data)/2, gocv.MatTypeCV16S, data)
+	if err != nil {
+		fmt.Println("Error converting results:", err)
+		return
+	}
 	results := fp16Results.ConvertFp16()
 
 	// determine the most probable classification


### PR DESCRIPTION
`gocv.NewMatFromBytes` returns 2 values. This fixes the call in `caffe/main.go`.

https://github.com/hybridgroup/gocv/blob/master/core.go#L142
```
// NewMatFromBytes returns a new Mat with a specific size and type, initialized from a []byte.
func NewMatFromBytes(rows int, cols int, mt MatType, data []byte) (Mat, error) {
```
