### PR TITLE
fix compile error on mac high sierra for uint type

### DIFF
--- a/ncs.h
+++ b/ncs.h
@@ -9,6 +9,8 @@
 
 #define NAME_SIZE 100
 
+typedef unsigned int uint;
+
 typedef struct ResultData{
   void* data;
   uint length;


### PR DESCRIPTION
when executing go build the following error was produced
./ncs.h:11:3: error: unknown type name 'uint'; did you mean 'int'?